### PR TITLE
Segregate autoload rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,11 @@
     },
     "autoload": {
         "psr-4": {
-            "Concat\\Http\\Middleware\\": "src/",
+            "Concat\\Http\\Middleware\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "Concat\\Http\\Middleware\\Test\\": "tests/"
         }
     },


### PR DESCRIPTION
There is no reason to provide autoload rules for a directory that is not
even present in production when you use the archive.

Refs https://github.com/phpspec/phpspec/issues/1174