### PR TITLE
Partially ported to PHPUnit v9.0.

### DIFF
--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -8,17 +8,21 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Promise\RejectedPromise;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LogLevel;
 use Psr\Log\LoggerInterface;
-use GuzzleHttp\Stream\Stream;
 
 use \Mockery as m;
 
-class LoggerTest extends \PHPUnit_Framework_TestCase
+class LoggerTest extends TestCase
 {
-    public function tearDown()
+
+    public function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 
@@ -43,8 +47,8 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
     {
         $response = m::mock(ResponseInterface::class);
         $response->shouldReceive('getStatusCode')->andReturn($code);
-        $response->shouldReceive('getBody')->andReturn(Stream::factory('test data'));
-        
+        $response->shouldReceive('getBody')->andReturn(\GuzzleHttp\Psr7\Utils::streamFor('test data'));
+
         return $response;
     }
 
@@ -57,20 +61,16 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidFormatter()
     {
+        $this->expectException(InvalidArgumentException::class);
         $logger = new Logger(m::mock(LoggerInterface::class));
         $logger->setFormatter(false);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidLogger()
     {
+        $this->expectException(InvalidArgumentException::class);
         $logger = new Logger(false);
     }
 
@@ -135,8 +135,8 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
     {
         $middleware = new Logger(function ($level, $message, $context) {
             $this->assertEquals($level, LogLevel::INFO);
-            $this->assertInternalType('string', $message);
-            $this->assertInternalType('array', $context);
+            $this->assertIsString($message);
+            $this->assertIsArray($context);
         });
 
         $response = $this->createMockResponse(200);


### PR DESCRIPTION
Virtually of the tests fail with this error:

    4) Concat\Http\Middleware\Test\LoggerTest::testLogLevel with data set #1 (200, Closure Object (...), 'level')
    Mockery\Exception\NoMatchingExpectationException: No matching handler found for Mockery_0_Psr_Log_LoggerInterface::log('level', '28fe67c45a51 ua - [13/Jul/2022:23:05:14 +0000] "GET / HTTP/1.1" 200 length', ['request' => object(GuzzleHttp\Psr7\Request), 'response' => object(Mockery_1_Psr_Http_Message_ResponseInterface), 'reason' => NULL]). Either the method was unexpected or its arguments matched no expected argument list for this method

References Issue #11.