### PR TITLE
Update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,13 @@
     "require": {
         "php": ">=7.2",
         "guzzlehttp/guzzle": "~6.0|^7.0",
+        "guzzlehttp/promises": "^1.0",
+        "guzzlehttp/psr7": "^1.7",
+        "psr/http-message": "^1.0",
         "psr/log": "^1.0|^2.0|^3.0"
     },
     "require-dev": {
-        "mockery/mockery": "^0.9.4",
+        "mockery/mockery": "^1.3.0",
         "phpunit/phpunit": "^8.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
         "php": ">=7.2",
         "guzzlehttp/guzzle": "~6.0|^7.0",
         "guzzlehttp/promises": "^1.0",
-        "guzzlehttp/psr7": "^1.7",
         "psr/http-message": "^1.0",
         "psr/log": "^1.0|^2.0|^3.0"
     },
     "require-dev": {
+        "guzzlehttp/psr7": "^1.7",
         "mockery/mockery": "^1.3.0",
         "phpunit/phpunit": "^8.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
         "psr/log": "^1.0|^2.0|^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.6",
-        "mockery/mockery": "^0.9.4"
+        "mockery/mockery": "^0.9.4",
+        "phpunit/phpunit": "^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -11,12 +11,13 @@ use GuzzleHttp\Promise\RejectedPromise;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LogLevel;
 use Psr\Log\LoggerInterface;
-use GuzzleHttp\Stream\Stream;
 
 use \Mockery as m;
 
 class LoggerTest extends \PHPUnit\Framework\TestCase
 {
+    use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
     public function tearDown(): void
     {
         m::close();
@@ -42,8 +43,8 @@ class LoggerTest extends \PHPUnit\Framework\TestCase
     private function createMockResponse($code)
     {
         $response = m::mock(ResponseInterface::class);
-        $response->shouldReceive('getStatusCode')->andReturn($code);
-        $response->shouldReceive('getBody')->andReturn(Stream::factory('test data'));
+        $response->allows('getStatusCode')->andReturns($code);
+        $response->allows('getBody')->andReturns(\GuzzleHttp\Psr7\Utils::streamFor('test data'));
         
         return $response;
     }
@@ -83,7 +84,7 @@ class LoggerTest extends \PHPUnit\Framework\TestCase
 
         $middleware = new Logger($logger);
         $response = $this->createMockResponse(200);
-        $response->shouldReceive('getHeaderLine')->andReturn("length");
+        $response->allows('getHeaderLine')->andReturns("length");
 
         $client = $this->createClient($middleware, [$response]);
         $client->get("/", [
@@ -103,7 +104,7 @@ class LoggerTest extends \PHPUnit\Framework\TestCase
         $middleware->setRequestLoggingEnabled(true);
 
         $response = $this->createMockResponse(200);
-        $response->shouldReceive('getHeaderLine')->andReturn("length");
+        $response->allows('getHeaderLine')->andReturns("length");
 
         $client = $this->createClient($middleware, [$response]);
         $client->get("/", [
@@ -123,7 +124,7 @@ class LoggerTest extends \PHPUnit\Framework\TestCase
         });
 
         $response = $this->createMockResponse(200);
-        $response->shouldReceive('getHeaderLine')->andReturn("length");
+        $response->allows('getHeaderLine')->andReturns("length");
 
         $client = $this->createClient($middleware, [$response]);
         $client->get("/", [
@@ -142,7 +143,7 @@ class LoggerTest extends \PHPUnit\Framework\TestCase
         });
 
         $response = $this->createMockResponse(200);
-        $response->shouldReceive('getHeaderLine')->andReturn("length");
+        $response->allows('getHeaderLine')->andReturns("length");
 
         $client = $this->createClient($middleware, [$response]);
         $client->get("/", [
@@ -186,7 +187,7 @@ class LoggerTest extends \PHPUnit\Framework\TestCase
         }
 
         $response = $this->createMockResponse($code);
-        $response->shouldReceive('getHeaderLine')->andReturn("length");
+        $response->allows('getHeaderLine')->andReturns("length");
 
         $client = $this->createClient($middleware, [$response]);
         $client->get("/", [

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -15,9 +15,9 @@ use GuzzleHttp\Stream\Stream;
 
 use \Mockery as m;
 
-class LoggerTest extends \PHPUnit_Framework_TestCase
+class LoggerTest extends \PHPUnit\Framework\TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
@@ -48,7 +48,7 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
         return $response;
     }
 
-    private function logBehaviour($logger, $count, $level, $code, $message = "")
+    private function logBehaviour($logger, $count, $level, $code, $message = ""): void
     {
         $logger->shouldReceive('log')->times($count)->with(
             $level,
@@ -58,23 +58,25 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
      */
-    public function testInvalidFormatter()
+    public function testInvalidFormatter(): void
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $logger = new Logger(m::mock(LoggerInterface::class));
         $logger->setFormatter(false);
     }
 
     /**
-     * @expectedException InvalidArgumentException
      */
-    public function testInvalidLogger()
+    public function testInvalidLogger(): void
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $logger = new Logger(false);
     }
 
-    public function testLogDefaults()
+    public function testLogDefaults(): void
     {
         $logger = m::mock(LoggerInterface::class);
         $this->logBehaviour($logger, 1, LogLevel::INFO, 200);
@@ -91,7 +93,7 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
         ]);
     }
 
-    public function testRequestLogging()
+    public function testRequestLogging(): void
     {
         $logger = m::mock(LoggerInterface::class);
         $this->logBehaviour($logger, 1, LogLevel::INFO, "NULL");
@@ -111,7 +113,7 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
         ]);
     }
 
-    public function testClosureFormatter()
+    public function testClosureFormatter(): void
     {
         $logger = m::mock(LoggerInterface::class);
         $this->logBehaviour($logger, 1, LogLevel::INFO, 200, "custom");
@@ -131,12 +133,12 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
         ]);
     }
 
-    public function testClosureLogger()
+    public function testClosureLogger(): void
     {
         $middleware = new Logger(function ($level, $message, $context) {
             $this->assertEquals($level, LogLevel::INFO);
-            $this->assertInternalType('string', $message);
-            $this->assertInternalType('array', $context);
+            $this->assertIsString($message);
+            $this->assertIsArray($context);
         });
 
         $response = $this->createMockResponse(200);
@@ -171,7 +173,7 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider logLevelProvider
      */
-    public function testLogLevel($code, $level, $expected)
+    public function testLogLevel($code, $level, $expected): void
     {
         $logger = m::mock(LoggerInterface::class);
         $this->logBehaviour($logger, 1, $expected, $code);
@@ -194,10 +196,11 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException GuzzleHttp\Exception\RequestException
      */
-    public function testFailureLog()
+    public function testFailureLog(): void
     {
+        $this->expectException(\GuzzleHttp\Exception\RequestException::class);
+
         $logger = m::mock(LoggerInterface::class);
         $this->logBehaviour($logger, 1, LogLevel::INFO, "NULL");
 
@@ -223,10 +226,11 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException GuzzleHttp\Exception\RequestException
      */
-    public function testFailureDoesNotLogTwice()
+    public function testFailureDoesNotLogTwice(): void
     {
+        $this->expectException(\GuzzleHttp\Exception\RequestException::class);
+
         $logger = m::mock(LoggerInterface::class);
         $this->logBehaviour($logger, 1, LogLevel::INFO, "NULL");
 

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -53,7 +53,7 @@ class LoggerTest extends \PHPUnit\Framework\TestCase
     {
         $logger->shouldReceive('log')->times($count)->with(
             $level,
-            $message ?: "~^.+ ua - \[.+\] \"GET / HTTP/1\.1\" $code .+$~",
+            $message ?: m::pattern("~^.+ ua - \[.+\] \"GET / HTTP/1\.1\" $code .+$~"),
             m::type('array')
         );
     }


### PR DESCRIPTION
I'm trying to get the dependencies updated. As this library is supporting PHP 7.2, the matching PHPUnit version is 8.

Also added are the Guzzle libs that are actively being used in the code, but were not mentioned until now, and were only present as transitive dependency. This leads to Guzzle 7.7 pulling in guzzlehttp/promises version 2, where the function `Promise\rejection_for` was removed.

If possible, merge and release this version as a patch version 1.0.1, no production code was changed. I'll try to provide another PR to finally upgrade the dependencies to reasonably latest versions.